### PR TITLE
feat: scaffold .codex/ prompts and skills during substrate init

### DIFF
--- a/src/cli/commands/__tests__/init-codex-scaffold.test.ts
+++ b/src/cli/commands/__tests__/init-codex-scaffold.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for project-scoped and user-scoped Codex scaffolding.
+ *
+ * Covers:
+ *   - scaffoldCodexProject mirrors .claude/{commands,skills}/ to .codex/{prompts,skills}/
+ *   - scaffoldCodexUser writes namespaced substrate-* entries to a home-dir .codex/
+ *   - Both functions are resilient when the source .claude/ dirs are absent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { scaffoldCodexProject, scaffoldCodexUser } from '../init.js'
+
+function seedClaudeScaffold(projectRoot: string): void {
+  const commandsDir = join(projectRoot, '.claude', 'commands')
+  const skillsDir = join(projectRoot, '.claude', 'skills')
+  mkdirSync(commandsDir, { recursive: true })
+  mkdirSync(skillsDir, { recursive: true })
+
+  writeFileSync(join(commandsDir, 'bmad-agent-pm.md'), '# PM agent command\n')
+  writeFileSync(join(commandsDir, 'substrate-run.md'), '# substrate-run\n')
+  // Non-markdown file should be ignored
+  writeFileSync(join(commandsDir, 'notes.txt'), 'ignore me')
+
+  const skillDir = join(skillsDir, 'bmad-agent-pm')
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: bmad-agent-pm\n---\n# skill\n')
+  writeFileSync(join(skillDir, 'helper.md'), '# helper\n')
+}
+
+describe('scaffoldCodexProject', () => {
+  let tempRoot: string
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'codex-scaffold-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('copies .claude/commands/*.md to .codex/prompts/*.md, skipping non-md files', () => {
+    seedClaudeScaffold(tempRoot)
+
+    scaffoldCodexProject(tempRoot, 'json')
+
+    const promptsDir = join(tempRoot, '.codex', 'prompts')
+    expect(existsSync(promptsDir)).toBe(true)
+
+    const entries = readdirSync(promptsDir).sort()
+    expect(entries).toEqual(['bmad-agent-pm.md', 'substrate-run.md'])
+    expect(readFileSync(join(promptsDir, 'bmad-agent-pm.md'), 'utf-8')).toBe('# PM agent command\n')
+  })
+
+  it('copies skill directories (with nested files) to .codex/skills/', () => {
+    seedClaudeScaffold(tempRoot)
+
+    scaffoldCodexProject(tempRoot, 'json')
+
+    const copied = join(tempRoot, '.codex', 'skills', 'bmad-agent-pm')
+    expect(existsSync(copied)).toBe(true)
+    expect(existsSync(join(copied, 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(copied, 'helper.md'))).toBe(true)
+  })
+
+  it('is a no-op and does not throw when .claude/ does not exist', () => {
+    expect(() => scaffoldCodexProject(tempRoot, 'json')).not.toThrow()
+    expect(existsSync(join(tempRoot, '.codex'))).toBe(false)
+  })
+
+  it('overwrites existing .codex/skills/<name> on re-scaffold (idempotent)', () => {
+    seedClaudeScaffold(tempRoot)
+
+    const staleDir = join(tempRoot, '.codex', 'skills', 'bmad-agent-pm')
+    mkdirSync(staleDir, { recursive: true })
+    writeFileSync(join(staleDir, 'stale.md'), 'stale')
+
+    scaffoldCodexProject(tempRoot, 'json')
+
+    expect(existsSync(join(staleDir, 'stale.md'))).toBe(false)
+    expect(existsSync(join(staleDir, 'SKILL.md'))).toBe(true)
+  })
+})
+
+describe('scaffoldCodexUser', () => {
+  let tempRoot: string
+  let fakeHome: string
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'codex-user-proj-'))
+    fakeHome = mkdtempSync(join(tmpdir(), 'codex-user-home-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+    rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  it('writes substrate-prefixed prompts and skills into ~/.codex/', () => {
+    seedClaudeScaffold(tempRoot)
+
+    scaffoldCodexUser(tempRoot, fakeHome, 'json')
+
+    const promptsDir = join(fakeHome, '.codex', 'prompts')
+    const skillsDir = join(fakeHome, '.codex', 'skills')
+
+    expect(readdirSync(promptsDir).sort()).toEqual([
+      'substrate-bmad-agent-pm.md',
+      'substrate-run.md', // already substrate-prefixed, not double-prefixed
+    ])
+    expect(readdirSync(skillsDir)).toEqual(['substrate-bmad-agent-pm'])
+    expect(existsSync(join(skillsDir, 'substrate-bmad-agent-pm', 'SKILL.md'))).toBe(true)
+  })
+
+  it('is a no-op and does not throw when .claude/ does not exist', () => {
+    expect(() => scaffoldCodexUser(tempRoot, fakeHome, 'json')).not.toThrow()
+    expect(existsSync(join(fakeHome, '.codex'))).toBe(false)
+  })
+})

--- a/src/cli/commands/__tests__/init-codex-scaffold.test.ts
+++ b/src/cli/commands/__tests__/init-codex-scaffold.test.ts
@@ -82,6 +82,29 @@ describe('scaffoldCodexProject', () => {
     expect(existsSync(join(staleDir, 'stale.md'))).toBe(false)
     expect(existsSync(join(staleDir, 'SKILL.md'))).toBe(true)
   })
+
+  it('prunes substrate-owned prompts and skills that disappeared from the source', () => {
+    seedClaudeScaffold(tempRoot)
+    const promptsDir = join(tempRoot, '.codex', 'prompts')
+    const skillsDir = join(tempRoot, '.codex', 'skills')
+
+    // Seed target with orphaned substrate-owned artifacts and one user-owned file
+    mkdirSync(promptsDir, { recursive: true })
+    writeFileSync(join(promptsDir, 'bmad-gone.md'), 'stale')
+    writeFileSync(join(promptsDir, 'my-own.md'), 'keep me')
+    mkdirSync(join(skillsDir, 'bmad-gone'), { recursive: true })
+    writeFileSync(join(skillsDir, 'bmad-gone', 'SKILL.md'), 'stale')
+    mkdirSync(join(skillsDir, 'user-custom'), { recursive: true })
+    writeFileSync(join(skillsDir, 'user-custom', 'SKILL.md'), 'keep me')
+
+    scaffoldCodexProject(tempRoot, 'json')
+
+    expect(existsSync(join(promptsDir, 'bmad-gone.md'))).toBe(false)
+    expect(existsSync(join(promptsDir, 'my-own.md'))).toBe(true)
+    expect(existsSync(join(skillsDir, 'bmad-gone'))).toBe(false)
+    expect(existsSync(join(skillsDir, 'user-custom'))).toBe(true)
+    expect(existsSync(join(promptsDir, 'bmad-agent-pm.md'))).toBe(true)
+  })
 })
 
 describe('scaffoldCodexUser', () => {
@@ -117,5 +140,29 @@ describe('scaffoldCodexUser', () => {
   it('is a no-op and does not throw when .claude/ does not exist', () => {
     expect(() => scaffoldCodexUser(tempRoot, fakeHome, 'json')).not.toThrow()
     expect(existsSync(join(fakeHome, '.codex'))).toBe(false)
+  })
+
+  it('prunes stale substrate-* entries but never touches non-substrate content', () => {
+    seedClaudeScaffold(tempRoot)
+    const promptsDir = join(fakeHome, '.codex', 'prompts')
+    const skillsDir = join(fakeHome, '.codex', 'skills')
+
+    mkdirSync(promptsDir, { recursive: true })
+    writeFileSync(join(promptsDir, 'substrate-gone.md'), 'stale')
+    writeFileSync(join(promptsDir, 'my-prompt.md'), 'keep me') // user-authored
+    writeFileSync(join(promptsDir, 'bmad-foo.md'), 'keep me') // not in our namespace
+    mkdirSync(join(skillsDir, 'substrate-gone'), { recursive: true })
+    writeFileSync(join(skillsDir, 'substrate-gone', 'SKILL.md'), 'stale')
+    mkdirSync(join(skillsDir, 'my-skill'), { recursive: true })
+    writeFileSync(join(skillsDir, 'my-skill', 'SKILL.md'), 'keep me')
+
+    scaffoldCodexUser(tempRoot, fakeHome, 'json')
+
+    expect(existsSync(join(promptsDir, 'substrate-gone.md'))).toBe(false)
+    expect(existsSync(join(promptsDir, 'my-prompt.md'))).toBe(true)
+    expect(existsSync(join(promptsDir, 'bmad-foo.md'))).toBe(true)
+    expect(existsSync(join(skillsDir, 'substrate-gone'))).toBe(false)
+    expect(existsSync(join(skillsDir, 'my-skill'))).toBe(true)
+    expect(existsSync(join(promptsDir, 'substrate-bmad-agent-pm.md'))).toBe(true)
   })
 })

--- a/src/cli/commands/__tests__/init-codex-scaffold.test.ts
+++ b/src/cli/commands/__tests__/init-codex-scaffold.test.ts
@@ -88,10 +88,12 @@ describe('scaffoldCodexProject', () => {
     const promptsDir = join(tempRoot, '.codex', 'prompts')
     const skillsDir = join(tempRoot, '.codex', 'skills')
 
-    // Seed target with orphaned substrate-owned artifacts and one user-owned file
+    // Seed target with orphaned substrate-owned artifacts and non-owned files
+    // (plugin-authored `ship.md`, user custom prompt, user custom skill dir)
     mkdirSync(promptsDir, { recursive: true })
     writeFileSync(join(promptsDir, 'bmad-gone.md'), 'stale')
     writeFileSync(join(promptsDir, 'my-own.md'), 'keep me')
+    writeFileSync(join(promptsDir, 'ship.md'), 'plugin-authored') // not substrate-owned
     mkdirSync(join(skillsDir, 'bmad-gone'), { recursive: true })
     writeFileSync(join(skillsDir, 'bmad-gone', 'SKILL.md'), 'stale')
     mkdirSync(join(skillsDir, 'user-custom'), { recursive: true })
@@ -101,9 +103,26 @@ describe('scaffoldCodexProject', () => {
 
     expect(existsSync(join(promptsDir, 'bmad-gone.md'))).toBe(false)
     expect(existsSync(join(promptsDir, 'my-own.md'))).toBe(true)
+    expect(existsSync(join(promptsDir, 'ship.md'))).toBe(true)
     expect(existsSync(join(skillsDir, 'bmad-gone'))).toBe(false)
     expect(existsSync(join(skillsDir, 'user-custom'))).toBe(true)
     expect(existsSync(join(promptsDir, 'bmad-agent-pm.md'))).toBe(true)
+  })
+
+  it('does not prune when source .claude/ is missing (protects last known good state)', () => {
+    // Do NOT seed — only the target has content (simulating a prior successful run
+    // followed by a run where bmad-method is transiently unavailable).
+    const promptsDir = join(tempRoot, '.codex', 'prompts')
+    const skillsDir = join(tempRoot, '.codex', 'skills')
+    mkdirSync(promptsDir, { recursive: true })
+    writeFileSync(join(promptsDir, 'bmad-agent-pm.md'), 'preserved')
+    mkdirSync(join(skillsDir, 'bmad-agent-pm'), { recursive: true })
+    writeFileSync(join(skillsDir, 'bmad-agent-pm', 'SKILL.md'), 'preserved')
+
+    scaffoldCodexProject(tempRoot, 'json')
+
+    expect(existsSync(join(promptsDir, 'bmad-agent-pm.md'))).toBe(true)
+    expect(existsSync(join(skillsDir, 'bmad-agent-pm', 'SKILL.md'))).toBe(true)
   })
 })
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -964,6 +964,154 @@ export async function scaffoldClaudeCommands(
 }
 
 // ---------------------------------------------------------------------------
+// Codex scaffolding (.codex/prompts/ + .codex/skills/)
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy every `.md` file from a source commands directory into a target prompts
+ * directory, flat. Codex CLI loads `<root>/.codex/prompts/*.md` as slash
+ * commands, so the already-generated Claude command files map 1:1.
+ *
+ * Returns the number of prompt files written.
+ */
+function copyCommandsAsPrompts(commandsDir: string, promptsDir: string): number {
+  if (!existsSync(commandsDir)) return 0
+  mkdirSync(promptsDir, { recursive: true })
+
+  let count = 0
+  try {
+    for (const entry of readdirSync(commandsDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+      const src = join(commandsDir, entry.name)
+      const dest = join(promptsDir, entry.name)
+      cpSync(src, dest)
+      count++
+    }
+  } catch (err) {
+    logger.debug({ err, commandsDir }, 'Failed to enumerate commands directory')
+  }
+  return count
+}
+
+/**
+ * Copy skill directories (dirs containing SKILL.md) from a source skills root
+ * into a target skills root, namespaced under `namespacePrefix` if provided.
+ *
+ * Returns the number of skill directories copied.
+ */
+function copySkillsToTarget(
+  srcSkillsDir: string,
+  destSkillsDir: string,
+  namespacePrefix: string,
+): number {
+  if (!existsSync(srcSkillsDir)) return 0
+  mkdirSync(destSkillsDir, { recursive: true })
+
+  let count = 0
+  try {
+    for (const entry of readdirSync(srcSkillsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const src = join(srcSkillsDir, entry.name)
+      const destName = namespacePrefix ? `${namespacePrefix}${entry.name}` : entry.name
+      const dest = join(destSkillsDir, destName)
+      rmSync(dest, { recursive: true, force: true })
+      cpSync(src, dest, { recursive: true })
+      count++
+    }
+  } catch (err) {
+    logger.debug({ err, srcSkillsDir }, 'Failed to enumerate source skills directory')
+  }
+  return count
+}
+
+/**
+ * Scaffold project-scoped Codex content from the already-generated
+ * `.claude/commands/` and `.claude/skills/`. Must run AFTER
+ * `scaffoldClaudeCommands`.
+ *
+ * Writes:
+ *   - <projectRoot>/.codex/prompts/*.md  (slash commands)
+ *   - <projectRoot>/.codex/skills/<skill>/  (skill bundles)
+ */
+export function scaffoldCodexProject(
+  projectRoot: string,
+  outputFormat: OutputFormat,
+): void {
+  const claudeCommandsDir = join(projectRoot, '.claude', 'commands')
+  const claudeSkillsDir = join(projectRoot, '.claude', 'skills')
+  const codexDir = join(projectRoot, '.codex')
+  const codexPromptsDir = join(codexDir, 'prompts')
+  const codexSkillsDir = join(codexDir, 'skills')
+
+  try {
+    const promptCount = copyCommandsAsPrompts(claudeCommandsDir, codexPromptsDir)
+    const skillCount = copySkillsToTarget(claudeSkillsDir, codexSkillsDir, '')
+
+    if (outputFormat !== 'json' && (promptCount > 0 || skillCount > 0)) {
+      process.stdout.write(
+        `Generated ${String(promptCount + skillCount)} Codex artifacts (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
+      )
+    }
+    logger.info({ promptCount, skillCount, codexDir }, 'Generated .codex/')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (outputFormat !== 'json') {
+      process.stderr.write(`Warning: .codex/ generation failed: ${msg}\n`)
+    }
+    logger.warn({ err }, 'scaffoldCodexProject failed; init continues')
+  }
+}
+
+/**
+ * Install Codex content user-wide at `~/.codex/`, namespaced under
+ * `substrate-` / `substrate-` to avoid colliding with user-installed content.
+ *
+ * Writes:
+ *   - ~/.codex/prompts/substrate-<slug>.md  (slash commands)
+ *   - ~/.codex/skills/substrate-<name>/     (skill bundles)
+ */
+export function scaffoldCodexUser(
+  projectRoot: string,
+  homeDir: string,
+  outputFormat: OutputFormat,
+): void {
+  const claudeCommandsDir = join(projectRoot, '.claude', 'commands')
+  const claudeSkillsDir = join(projectRoot, '.claude', 'skills')
+  const userCodexDir = join(homeDir, '.codex')
+  const userPromptsDir = join(userCodexDir, 'prompts')
+  const userSkillsDir = join(userCodexDir, 'skills')
+
+  try {
+    // Prompts: rename each file to substrate-<original>
+    let promptCount = 0
+    if (existsSync(claudeCommandsDir)) {
+      mkdirSync(userPromptsDir, { recursive: true })
+      for (const entry of readdirSync(claudeCommandsDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+        const baseName = entry.name.startsWith('substrate-') ? entry.name : `substrate-${entry.name}`
+        cpSync(join(claudeCommandsDir, entry.name), join(userPromptsDir, baseName))
+        promptCount++
+      }
+    }
+
+    const skillCount = copySkillsToTarget(claudeSkillsDir, userSkillsDir, 'substrate-')
+
+    if (outputFormat !== 'json' && (promptCount > 0 || skillCount > 0)) {
+      process.stdout.write(
+        `Installed ${String(promptCount + skillCount)} Codex artifacts to ${userCodexDir} (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
+      )
+    }
+    logger.info({ promptCount, skillCount, userCodexDir }, 'Installed user-scope Codex content')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (outputFormat !== 'json') {
+      process.stderr.write(`Warning: user-scope Codex install failed: ${msg}\n`)
+    }
+    logger.warn({ err }, 'scaffoldCodexUser failed; init continues')
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Provider config builder (from old init.ts)
 // ---------------------------------------------------------------------------
 
@@ -1128,6 +1276,11 @@ export interface InitOptions {
    *   'skip'  — skip Dolt bootstrapping entirely
    */
   doltMode?: 'auto' | 'force' | 'skip'
+  /**
+   * When true, additionally install Codex prompts/skills into `~/.codex/`,
+   * namespaced under `substrate-` to avoid collisions. Default: false.
+   */
+  installUserScope?: boolean
 }
 
 /**
@@ -1381,6 +1534,15 @@ export async function runInitAction(options: InitOptions): Promise<number> {
     await scaffoldStatuslineScript(projectRoot)
     await scaffoldClaudeSettings(projectRoot)
     await scaffoldClaudeCommands(projectRoot, outputFormat)
+    scaffoldCodexProject(projectRoot, outputFormat)
+    if (options.installUserScope) {
+      const homeDir = process.env['HOME'] ?? process.env['USERPROFILE']
+      if (homeDir) {
+        scaffoldCodexUser(projectRoot, homeDir, outputFormat)
+      } else if (outputFormat !== 'json') {
+        process.stderr.write('Warning: --install-user-scope requested but HOME is not set\n')
+      }
+    }
 
     // Ensure substrate runtime and factory files are gitignored
     const gitignorePath = join(projectRoot, '.gitignore')
@@ -1478,6 +1640,8 @@ export async function runInitAction(options: InitOptions): Promise<number> {
       process.stdout.write(`    AGENTS.md             pipeline instructions for Codex CLI\n`)
       process.stdout.write(`    GEMINI.md             pipeline instructions for Gemini CLI\n`)
       process.stdout.write(`    .claude/commands/     /substrate-run, /substrate-supervisor, /substrate-metrics\n`)
+      process.stdout.write(`    .codex/prompts/       Codex slash commands (mirror of .claude/commands/)\n`)
+      process.stdout.write(`    .codex/skills/        Codex skill bundles (mirror of .claude/skills/)\n`)
       process.stdout.write(`    .substrate/           config, database, routing policy\n`)
 
       if (doltInitialized) {
@@ -1534,6 +1698,7 @@ export function registerInitCommand(
     )
     .option('--dolt', 'Initialize Dolt state database as part of init (forces Dolt bootstrapping)', false)
     .option('--no-dolt', 'Skip Dolt state store initialization even if Dolt is installed')
+    .option('--install-user-scope', 'Also install Codex prompts/skills into ~/.codex/ (namespaced substrate-*)', false)
     .action(async (opts: {
       pack: string
       projectRoot: string
@@ -1542,6 +1707,7 @@ export function registerInitCommand(
       outputFormat: string
       dolt: boolean
       noDolt: boolean
+      installUserScope: boolean
     }) => {
       const outputFormat: OutputFormat = opts.outputFormat === 'json' ? 'json' : 'human'
 
@@ -1554,6 +1720,7 @@ export function registerInitCommand(
         force: opts.force,
         yes: opts.yes,
         doltMode,
+        installUserScope: opts.installUserScope,
         ...(registry !== undefined && { registry }),
       })
       process.exitCode = exitCode

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -985,17 +985,16 @@ function syncCommandsAsPrompts(
   ownershipPrefixes: string[],
   namePrefix: string,
 ): number {
-  const sourceExists = existsSync(commandsDir)
-  const destExists = existsSync(promptsDir)
-  if (!sourceExists && !destExists) return 0
+  // If the source directory is missing, we have no authoritative set to mirror
+  // against — never prune, never populate, to avoid destroying preserved content
+  // when `.claude/commands/` is transiently absent (e.g., bmad-method missing).
+  if (!existsSync(commandsDir)) return 0
 
   mkdirSync(promptsDir, { recursive: true })
 
-  const sourceEntries = sourceExists
-    ? readdirSync(commandsDir, { withFileTypes: true }).filter(
-        (e) => e.isFile() && e.name.endsWith('.md'),
-      )
-    : []
+  const sourceEntries = readdirSync(commandsDir, { withFileTypes: true }).filter(
+    (e) => e.isFile() && e.name.endsWith('.md'),
+  )
 
   const destNames = new Set(
     sourceEntries.map((e) =>
@@ -1043,15 +1042,15 @@ function syncSkillsToTarget(
   ownershipPrefixes: string[],
   namePrefix: string,
 ): number {
-  const sourceExists = existsSync(srcSkillsDir)
-  const destExists = existsSync(destSkillsDir)
-  if (!sourceExists && !destExists) return 0
+  // Same rationale as syncCommandsAsPrompts: bail if source is missing so we
+  // never prune preserved content without an authoritative mirror target.
+  if (!existsSync(srcSkillsDir)) return 0
 
   mkdirSync(destSkillsDir, { recursive: true })
 
-  const sourceEntries = sourceExists
-    ? readdirSync(srcSkillsDir, { withFileTypes: true }).filter((e) => e.isDirectory())
-    : []
+  const sourceEntries = readdirSync(srcSkillsDir, { withFileTypes: true }).filter((e) =>
+    e.isDirectory(),
+  )
 
   const destNames = new Set(
     sourceEntries.map((e) =>
@@ -1083,9 +1082,11 @@ function syncSkillsToTarget(
   return count
 }
 
-// Project-scoped Codex dirs are fully owned by substrate, so any bmad-/ship-/
-// substrate-prefixed file is fair game to remove on re-runs.
-const PROJECT_OWNERSHIP_PREFIXES = ['bmad-', 'substrate-', 'ship']
+// Prefixes of prompts/skills substrate itself writes into `.codex/` (the same
+// names substrate init produces in `.claude/commands/` + `.claude/skills/`).
+// Non-prefixed files (e.g., `ship.md` from the superpowers plugin) are never
+// pruned — they belong to whatever tool installed them.
+const PROJECT_OWNERSHIP_PREFIXES = ['bmad-', 'substrate-']
 
 /**
  * Scaffold project-scoped Codex content from the already-generated
@@ -1096,8 +1097,9 @@ const PROJECT_OWNERSHIP_PREFIXES = ['bmad-', 'substrate-', 'ship']
  *   - <projectRoot>/.codex/prompts/*.md  (slash commands)
  *   - <projectRoot>/.codex/skills/<skill>/  (skill bundles)
  *
- * Stale substrate-owned entries (bmad-*, substrate-*, ship*) from previous
- * runs are pruned before new content is written.
+ * Stale substrate-owned entries (bmad-*, substrate-*) from previous runs are
+ * pruned before new content is written. Non-owned files (e.g., `ship.md` from
+ * a plugin) are left alone.
  */
 export function scaffoldCodexProject(
   projectRoot: string,
@@ -1629,7 +1631,9 @@ export async function runInitAction(options: InitOptions): Promise<number> {
       if (homeDir) {
         scaffoldCodexUser(projectRoot, homeDir, outputFormat)
       } else if (outputFormat !== 'json') {
-        process.stderr.write('Warning: --install-user-scope requested but HOME is not set\n')
+        process.stderr.write(
+          'Warning: --install-user-scope requested but HOME/USERPROFILE is not set\n',
+        )
       }
     }
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -968,61 +968,124 @@ export async function scaffoldClaudeCommands(
 // ---------------------------------------------------------------------------
 
 /**
- * Copy every `.md` file from a source commands directory into a target prompts
+ * Sync every `.md` file from a source commands directory into a target prompts
  * directory, flat. Codex CLI loads `<root>/.codex/prompts/*.md` as slash
  * commands, so the already-generated Claude command files map 1:1.
  *
+ * On re-runs, any `.md` file in the target that matches `ownershipPrefixes`
+ * but is no longer present in the source is removed, so stale substrate-
+ * generated prompts don't accumulate. `.md` files without a matching prefix
+ * are left untouched (protecting user-authored content in `~/.codex/`).
+ *
  * Returns the number of prompt files written.
  */
-function copyCommandsAsPrompts(commandsDir: string, promptsDir: string): number {
-  if (!existsSync(commandsDir)) return 0
+function syncCommandsAsPrompts(
+  commandsDir: string,
+  promptsDir: string,
+  ownershipPrefixes: string[],
+  namePrefix: string,
+): number {
+  const sourceExists = existsSync(commandsDir)
+  const destExists = existsSync(promptsDir)
+  if (!sourceExists && !destExists) return 0
+
   mkdirSync(promptsDir, { recursive: true })
 
-  let count = 0
+  const sourceEntries = sourceExists
+    ? readdirSync(commandsDir, { withFileTypes: true }).filter(
+        (e) => e.isFile() && e.name.endsWith('.md'),
+      )
+    : []
+
+  const destNames = new Set(
+    sourceEntries.map((e) =>
+      namePrefix && !e.name.startsWith(namePrefix) ? `${namePrefix}${e.name}` : e.name,
+    ),
+  )
+
   try {
-    for (const entry of readdirSync(commandsDir, { withFileTypes: true })) {
+    for (const entry of readdirSync(promptsDir, { withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith('.md')) continue
-      const src = join(commandsDir, entry.name)
-      const dest = join(promptsDir, entry.name)
-      cpSync(src, dest)
-      count++
+      const isOwned = ownershipPrefixes.some((p) => entry.name.startsWith(p))
+      if (!isOwned) continue
+      if (destNames.has(entry.name)) continue
+      unlinkSync(join(promptsDir, entry.name))
     }
   } catch (err) {
-    logger.debug({ err, commandsDir }, 'Failed to enumerate commands directory')
+    logger.debug({ err, promptsDir }, 'Failed to prune stale prompts')
+  }
+
+  let count = 0
+  for (const entry of sourceEntries) {
+    const destName =
+      namePrefix && !entry.name.startsWith(namePrefix) ? `${namePrefix}${entry.name}` : entry.name
+    cpSync(join(commandsDir, entry.name), join(promptsDir, destName))
+    count++
   }
   return count
 }
 
 /**
- * Copy skill directories (dirs containing SKILL.md) from a source skills root
- * into a target skills root, namespaced under `namespacePrefix` if provided.
+ * Sync skill directories from a source skills root into a target skills root,
+ * optionally namespaced under `namePrefix`.
+ *
+ * Every direct child directory of `srcSkillsDir` is treated as a skill bundle
+ * (no SKILL.md check — the source is always `.claude/skills/` which has
+ * already been sanitized by `prepareSkillsDir`). On re-runs, any skill
+ * directory in the target whose name starts with one of `ownershipPrefixes`
+ * but is no longer present in the source is removed.
  *
  * Returns the number of skill directories copied.
  */
-function copySkillsToTarget(
+function syncSkillsToTarget(
   srcSkillsDir: string,
   destSkillsDir: string,
-  namespacePrefix: string,
+  ownershipPrefixes: string[],
+  namePrefix: string,
 ): number {
-  if (!existsSync(srcSkillsDir)) return 0
+  const sourceExists = existsSync(srcSkillsDir)
+  const destExists = existsSync(destSkillsDir)
+  if (!sourceExists && !destExists) return 0
+
   mkdirSync(destSkillsDir, { recursive: true })
 
-  let count = 0
+  const sourceEntries = sourceExists
+    ? readdirSync(srcSkillsDir, { withFileTypes: true }).filter((e) => e.isDirectory())
+    : []
+
+  const destNames = new Set(
+    sourceEntries.map((e) =>
+      namePrefix && !e.name.startsWith(namePrefix) ? `${namePrefix}${e.name}` : e.name,
+    ),
+  )
+
   try {
-    for (const entry of readdirSync(srcSkillsDir, { withFileTypes: true })) {
+    for (const entry of readdirSync(destSkillsDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue
-      const src = join(srcSkillsDir, entry.name)
-      const destName = namespacePrefix ? `${namespacePrefix}${entry.name}` : entry.name
-      const dest = join(destSkillsDir, destName)
-      rmSync(dest, { recursive: true, force: true })
-      cpSync(src, dest, { recursive: true })
-      count++
+      const isOwned = ownershipPrefixes.some((p) => entry.name.startsWith(p))
+      if (!isOwned) continue
+      if (destNames.has(entry.name)) continue
+      rmSync(join(destSkillsDir, entry.name), { recursive: true, force: true })
     }
   } catch (err) {
-    logger.debug({ err, srcSkillsDir }, 'Failed to enumerate source skills directory')
+    logger.debug({ err, destSkillsDir }, 'Failed to prune stale skills')
+  }
+
+  let count = 0
+  for (const entry of sourceEntries) {
+    const destName =
+      namePrefix && !entry.name.startsWith(namePrefix) ? `${namePrefix}${entry.name}` : entry.name
+    const dest = join(destSkillsDir, destName)
+    rmSync(dest, { recursive: true, force: true })
+    cpSync(join(srcSkillsDir, entry.name), dest, { recursive: true })
+    count++
   }
   return count
 }
+
+// Project-scoped Codex dirs are fully owned by substrate, so any bmad-/ship-/
+// substrate-prefixed file is fair game to remove on re-runs.
+const PROJECT_OWNERSHIP_PREFIXES = ['bmad-', 'substrate-', 'ship']
 
 /**
  * Scaffold project-scoped Codex content from the already-generated
@@ -1032,6 +1095,9 @@ function copySkillsToTarget(
  * Writes:
  *   - <projectRoot>/.codex/prompts/*.md  (slash commands)
  *   - <projectRoot>/.codex/skills/<skill>/  (skill bundles)
+ *
+ * Stale substrate-owned entries (bmad-*, substrate-*, ship*) from previous
+ * runs are pruned before new content is written.
  */
 export function scaffoldCodexProject(
   projectRoot: string,
@@ -1044,15 +1110,30 @@ export function scaffoldCodexProject(
   const codexSkillsDir = join(codexDir, 'skills')
 
   try {
-    const promptCount = copyCommandsAsPrompts(claudeCommandsDir, codexPromptsDir)
-    const skillCount = copySkillsToTarget(claudeSkillsDir, codexSkillsDir, '')
+    const promptCount = syncCommandsAsPrompts(
+      claudeCommandsDir,
+      codexPromptsDir,
+      PROJECT_OWNERSHIP_PREFIXES,
+      '',
+    )
+    const skillCount = syncSkillsToTarget(
+      claudeSkillsDir,
+      codexSkillsDir,
+      PROJECT_OWNERSHIP_PREFIXES,
+      '',
+    )
 
-    if (outputFormat !== 'json' && (promptCount > 0 || skillCount > 0)) {
+    const total = promptCount + skillCount
+    if (outputFormat !== 'json' && total > 0) {
       process.stdout.write(
-        `Generated ${String(promptCount + skillCount)} Codex artifacts (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
+        `Generated ${String(total)} Codex artifacts (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
       )
     }
-    logger.info({ promptCount, skillCount, codexDir }, 'Generated .codex/')
+    if (total > 0) {
+      logger.info({ promptCount, skillCount, codexDir }, 'Generated .codex/')
+    } else {
+      logger.debug({ codexDir }, 'No Codex artifacts generated; source Claude content not found')
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     if (outputFormat !== 'json') {
@@ -1064,11 +1145,15 @@ export function scaffoldCodexProject(
 
 /**
  * Install Codex content user-wide at `~/.codex/`, namespaced under
- * `substrate-` / `substrate-` to avoid colliding with user-installed content.
+ * `substrate-` to avoid colliding with user-installed content.
  *
  * Writes:
  *   - ~/.codex/prompts/substrate-<slug>.md  (slash commands)
  *   - ~/.codex/skills/substrate-<name>/     (skill bundles)
+ *
+ * Stale `substrate-*` entries from previous runs are pruned before new
+ * content is written. Files/directories without the `substrate-` prefix
+ * are never touched.
  */
 export function scaffoldCodexUser(
   projectRoot: string,
@@ -1082,26 +1167,30 @@ export function scaffoldCodexUser(
   const userSkillsDir = join(userCodexDir, 'skills')
 
   try {
-    // Prompts: rename each file to substrate-<original>
-    let promptCount = 0
-    if (existsSync(claudeCommandsDir)) {
-      mkdirSync(userPromptsDir, { recursive: true })
-      for (const entry of readdirSync(claudeCommandsDir, { withFileTypes: true })) {
-        if (!entry.isFile() || !entry.name.endsWith('.md')) continue
-        const baseName = entry.name.startsWith('substrate-') ? entry.name : `substrate-${entry.name}`
-        cpSync(join(claudeCommandsDir, entry.name), join(userPromptsDir, baseName))
-        promptCount++
-      }
-    }
+    const promptCount = syncCommandsAsPrompts(
+      claudeCommandsDir,
+      userPromptsDir,
+      ['substrate-'],
+      'substrate-',
+    )
+    const skillCount = syncSkillsToTarget(
+      claudeSkillsDir,
+      userSkillsDir,
+      ['substrate-'],
+      'substrate-',
+    )
 
-    const skillCount = copySkillsToTarget(claudeSkillsDir, userSkillsDir, 'substrate-')
-
-    if (outputFormat !== 'json' && (promptCount > 0 || skillCount > 0)) {
+    const total = promptCount + skillCount
+    if (outputFormat !== 'json' && total > 0) {
       process.stdout.write(
-        `Installed ${String(promptCount + skillCount)} Codex artifacts to ${userCodexDir} (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
+        `Installed ${String(total)} Codex artifacts to ${userCodexDir} (${String(promptCount)} prompts, ${String(skillCount)} skills)\n`,
       )
     }
-    logger.info({ promptCount, skillCount, userCodexDir }, 'Installed user-scope Codex content')
+    if (total > 0) {
+      logger.info({ promptCount, skillCount, userCodexDir }, 'Installed user-scope Codex content')
+    } else {
+      logger.debug({ userCodexDir }, 'No user-scope Codex content installed; source Claude content not found')
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     if (outputFormat !== 'json') {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1646,6 +1646,8 @@ export async function runInitAction(options: InitOptions): Promise<number> {
       '.substrate/state/',
       '.substrate/substrate.db',
       '.substrate/substrate.db-journal',
+      '.codex/prompts/',
+      '.codex/skills/',
     ]
     try {
       const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : ''


### PR DESCRIPTION
## Summary

- `substrate init` previously wrote only a top-level `AGENTS.md` for Codex — no slash commands or skills were ever generated, while Claude got the full `.claude/commands/` + `.claude/skills/` tree.
- Adds `scaffoldCodexProject()` that mirrors those trees into `.codex/prompts/*.md` and `.codex/skills/<name>/` after the Claude scaffold runs (content is identical, no need to re-run bmad-method generators).
- Adds `scaffoldCodexUser()` behind a new `--install-user-scope` flag that installs `substrate-*` namespaced entries into `~/.codex/` to avoid colliding with any user-installed skills/prompts.

## Test plan

- [x] 6 new integration tests using real tmp dirs (no fs mocking) — all green
- [x] Full `init` test suite (44 tests) passes
- [x] Adjacent scaffold tests (`auto-claude-commands-scaffold`, `auto-init-scaffolding.integration`) pass
- [x] Build succeeds
- [x] E2E: fresh `substrate init` on a tmp dir populates 43 skills into `.codex/skills/`
- [x] E2E: `--install-user-scope` with a fake `HOME` populates `substrate-*` namespaced entries in `~/.codex/{prompts,skills}/`

## Out of scope

`.gemini/` parity — same gap exists for Gemini CLI but intentionally deferred to a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)