### PR TITLE
Epic 81 / Story 81-5: Pack-Upgrade CI workflow + setup docs (REPORT-ONLY, gated on Story 81-6)

### DIFF
--- a/.github/workflows/eval-pack-upgrade.yml
+++ b/.github/workflows/eval-pack-upgrade.yml
@@ -1,0 +1,153 @@
+# Pack-Upgrade A/B Evaluation — Story 81-5
+#
+# Triggers on PRs that touch packs/bmad/**. Runs scripts/eval-pack-upgrade.mjs
+# with the base branch's pack as --pack-current and the PR's pack as
+# --pack-candidate. Posts the four-axis markdown report as a PR comment
+# (update-in-place via a marker), uploads the JSON report as an artifact.
+#
+# CURRENT STATUS (2026-05-31): REPORT-ONLY. The workflow exits 0 regardless
+# of the CLI's verdict-driven exit code. This is by design per Epic 81 Design
+# Principle 4 — observe real signal distributions for 2–3 calibration runs
+# before promoting to a blocking gate.
+#
+# IMPORTANT — DEFERRED CAPABILITY: as of v0.20.138, both substrate eval
+# harnesses (Epic 77 reconstruction AND Epic 81 pack-upgrade) ship with the
+# production dispatcher wiring STUBBED (intentional, deferred by the original
+# Story 77-8 and 81-2 implementations). Until Story 81-6 wires the real
+# dispatcher (~300–500 LOC unlock for BOTH tiers), this workflow will post
+# vacuous GREEN reports — every pair returns `both-incomplete` because the
+# stubbed dispatch throws, the grader sees zero gradable pairs, and the
+# overall verdict defaults to GREEN by absence of regressions.
+#
+# See docs/2026-05-31-epic-81-first-calibration.md for the full
+# architectural finding and Story 81-6 scope.
+#
+# PROMOTION-TO-GATE CRITERIA (operator to flip after 2–3 calibration runs):
+#   1. Story 81-6 (production dispatcher wiring) MERGED
+#   2. ≥ 3 pack-upgrade PRs observed with real (non-vacuous) signal
+#   3. Threshold distributions tuned against the operator's quality bar
+#   4. At least one INTENTIONAL regression tested end-to-end through this
+#      gate confirms RED → blocking behavior
+
+name: Pack-Upgrade A/B Evaluation
+on:
+  pull_request:
+    paths:
+      - 'packs/bmad/**'
+
+# Skip fork PRs to avoid leaking secrets. Reconsider for fork-PR support
+# in a follow-up once secret-scoping rules are settled.
+jobs:
+  pack-upgrade-evaluation:
+    name: Pack-Upgrade A/B
+    runs-on: ubuntu-latest
+    timeout-minutes: 1440  # 24 hours; full 35-pair A/B can take 10–20 hours of compute
+    permissions:
+      contents: read
+      pull-requests: write  # for PR-comment posting
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      # Substrate dispatch in CI requires API-key auth — Claude Code OAuth session
+      # is not available in GHA per [[feedback_substrate_dispatch_disciplines]].
+      # The secret ANTHROPIC_API_KEY MUST be configured at the repo level
+      # before this workflow can run successfully (see docs/eval-pack-upgrade-ci-setup.md).
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Checkout PR head (candidate pack at packs/bmad)
+        uses: actions/checkout@v4
+        with:
+          path: pr-head
+          fetch-depth: 2  # need parent SHA for ground-truth diff resolution
+      - name: Checkout base branch (current pack at base-pack/bmad)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base-pack
+          sparse-checkout: |
+            packs/bmad
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'pr-head/package-lock.json'
+      - name: Install dependencies
+        working-directory: pr-head
+        run: npm ci
+      - name: Build
+        working-directory: pr-head
+        run: npm run build
+      - name: Run pack-upgrade evaluation
+        id: eval
+        working-directory: pr-head
+        # Default thresholds (operator-tunable after calibration):
+        #   code-quality:0.05 cost-turns:0.10 verdict-tv:0.10 recovery-tv:0.10
+        # Exit codes: 0=GREEN, 1=YELLOW, 2=RED, 3=usage-error, 4=internal-exception
+        # Captured into step output `verdict-exit` for the comment poster to surface.
+        run: |
+          set +e
+          node scripts/eval-pack-upgrade.mjs \
+            --pack-current ../base-pack/packs/bmad \
+            --pack-candidate packs/bmad \
+            --format markdown \
+            --output pack-upgrade-report.md \
+            --threshold code-quality:0.05,cost-turns:0.10,verdict-tv:0.10,recovery-tv:0.10
+          VERDICT_EXIT=$?
+          echo "verdict-exit=$VERDICT_EXIT" >> "$GITHUB_OUTPUT"
+          # Also dump the JSON for artifact upload + future history
+          node scripts/eval-pack-upgrade.mjs \
+            --pack-current ../base-pack/packs/bmad \
+            --pack-candidate packs/bmad \
+            --format json \
+            --output pack-upgrade-report.json \
+            --threshold code-quality:0.05,cost-turns:0.10,verdict-tv:0.10,recovery-tv:0.10 || true
+          # Report-only mode: always exit 0 regardless of verdict-exit
+          exit 0
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pack-upgrade-report-${{ github.event.pull_request.number }}
+          path: |
+            pr-head/pack-upgrade-report.md
+            pr-head/pack-upgrade-report.json
+          retention-days: 90
+      - name: Post or update PR comment
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          VERDICT_EXIT: ${{ steps.eval.outputs.verdict-exit }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const marker = '<!-- pack-upgrade-report -->';
+            const verdictExit = process.env.VERDICT_EXIT || 'unknown';
+            const reportPath = 'pr-head/pack-upgrade-report.md';
+
+            let reportBody;
+            try {
+              reportBody = fs.readFileSync(reportPath, 'utf8');
+            } catch (err) {
+              reportBody = `_pack-upgrade evaluation failed to produce a report (${err.message})._`;
+            }
+
+            const header = `${marker}\n\n` +
+              `<sub>CLI exit code: \`${verdictExit}\` (0=GREEN, 1=YELLOW, 2=RED, 3=usage-error, 4=internal-exception). ` +
+              `**Report-only mode — workflow does not block merge regardless of verdict.** ` +
+              `See \`docs/eval-pack-upgrade-ci-setup.md\` for the promotion-to-gate criteria.</sub>\n\n`;
+
+            const body = header + reportBody;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find(c => c.body && c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated existing comment id=${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info(`Created new comment on issue #${issue_number}`);
+            }

--- a/docs/eval-pack-upgrade-ci-setup.md
+++ b/docs/eval-pack-upgrade-ci-setup.md
@@ -1,0 +1,144 @@
+# Pack-Upgrade Evaluation CI — Setup & Operations Guide
+
+> **Status (2026-05-31): WORKFLOW SHIPPED, CAPABILITY DEFERRED.**
+> The workflow yaml at `.github/workflows/eval-pack-upgrade.yml` is wired and
+> ready, but it currently posts **vacuous GREEN** reports on every pack-touching
+> PR because both substrate eval harnesses (Epic 77 reconstruction + Epic 81
+> pack-upgrade) ship with `deps.dispatch` STUBBED. Story 81-6 (production
+> dispatcher wiring) unblocks both tiers in a single ship.
+>
+> Read `docs/2026-05-31-epic-81-first-calibration.md` for the full
+> architectural finding + 81-6 scope before configuring this workflow.
+
+## What this workflow does
+
+Trigger: PRs that modify any file under `packs/bmad/**`.
+
+Job:
+1. Checks out the PR head (candidate pack) and the base branch's pack (current)
+2. Installs deps, builds
+3. Runs `scripts/eval-pack-upgrade.mjs` with both packs and the full Epic 77
+   regression corpus
+4. Posts the four-axis markdown report as a PR comment (update-in-place via
+   a `<!-- pack-upgrade-report -->` marker)
+5. Uploads the markdown + JSON reports as workflow artifacts (90-day retention)
+
+The workflow is **report-only** — it always exits 0 regardless of the CLI's
+verdict-driven exit code. The CLI's exit code is surfaced in a `<sub>` line
+at the top of the PR comment so reviewers can see GREEN/YELLOW/RED at a glance.
+
+## Required GitHub secret
+
+```
+ANTHROPIC_API_KEY  — required for substrate dispatch in CI
+```
+
+Add this at **Settings → Secrets and variables → Actions → New repository secret**.
+
+OAuth session-based auth (substrate's local default per
+`[[feedback_substrate_dispatch_disciplines]]`) is NOT available in GHA;
+API-key auth is the CI path.
+
+## Required corpus state
+
+`_bmad-output/eval-results/corpus/outcomes-corpus.yaml` is the default corpus.
+For the harness to actually dispatch (vs return vacuous GREEN), each corpus
+entry must have `parent_sha`, `commit_sha`, and `story_file_input_path`
+populated. The Epic 77 35-pair corpus does NOT have these fields today — it
+predates F-commitsha (v0.20.118) and obs_027 (v0.20.124).
+
+Override the corpus via `--corpus <path>` in the workflow step if a curated
+fixture is desired. A 4-pair fixture for substrate-self is at
+`_bmad-output/eval-results/corpus/pack-upgrade-fixture-corpus.yaml`.
+
+## Cost ceiling
+
+- Full corpus: 35 pairs × 2 packs × ~5–40 min/dispatch = ~6–47 compute-hours
+- Per-dispatch budget cap: $2.00 (configurable via `--budget-per-case-usd`)
+- Worst-case per pack-upgrade PR: **~$140** (rare; typical $30–$70)
+- Workflow timeout: 24 hours
+
+This is acceptable spend on a pack-upgrade-PR frequency of ~1–5 per quarter.
+On heavier frequencies, reconsider the corpus size or trigger criteria.
+
+## Reading the report
+
+The markdown report (also the PR comment body) has this structure:
+
+```
+# Pack-upgrade evaluation report
+**Current pack**: <path> @ <version-or-sha>
+**Candidate pack**: <path> @ <version-or-sha>
+**Corpus**: <file>, <N> pairs, <M> completed both, <K> ungradable
+**Overall verdict**: 🟢 GREEN | 🟡 YELLOW | 🔴 RED
+
+## Axis verdicts
+| Axis | Verdict | Headline |
+| --- | --- | --- |
+| Code quality | … | mean Δ = … |
+| Cost | … | mean Δ turns = … |
+| Verdict distribution | … | TV = … |
+| Recovery taxonomy | … | TV = … |
+
+## Per-axis detail
+… top regressions per axis …
+```
+
+**A vacuous-GREEN report** (every axis "ungradable_count" == N) means the
+harness ran but produced no measurements — the dispatcher stub is the
+likely cause until 81-6 ships.
+
+## Promotion-to-gate criteria
+
+The workflow ships in **report-only mode**. To promote to a **blocking gate**
+(workflow fails on RED/YELLOW), the operator must verify:
+
+1. **Story 81-6 merged** — production dispatcher is actually wired, so the
+   harness produces real measurements
+2. **≥ 3 pack-upgrade PRs observed** with real (non-vacuous) signal — gives
+   the operator a sense of the natural distribution
+3. **Thresholds tuned** against the operator's quality bar — the defaults
+   (`code-quality:0.05, cost-turns:0.10, verdict-tv:0.10, recovery-tv:0.10`)
+   are starting points, not validated against substrate's actual signal
+4. **One intentional regression tested end-to-end** — confirms the workflow
+   surfaces RED correctly when given a deliberately-degraded pack
+
+To promote, edit `.github/workflows/eval-pack-upgrade.yml`:
+- Remove the `exit 0` in the "Run pack-upgrade evaluation" step
+- Or replace the final `exit 0` with `exit $VERDICT_EXIT`
+- Add a header-comment block documenting the flip date and the calibration
+  observations that justified it
+
+## Troubleshooting
+
+**"vacuous GREEN" on every PR** — Expected today. Until Story 81-6 wires the
+production dispatcher, the harness cannot actually dispatch. See
+`docs/2026-05-31-epic-81-first-calibration.md`.
+
+**"corpus pollution — 40 corpus-errors"** — The default Epic 77 corpus lacks
+`parent_sha`. Use `--corpus _bmad-output/eval-results/corpus/pack-upgrade-fixture-corpus.yaml`
+for the 4-pair substrate-self fixture instead, or wait for a corpus-extension
+story to populate parent_sha for the Epic 77 entries.
+
+**Workflow times out at 24 hours** — Increase `timeout-minutes` (note: GHA
+caps at 360 for free tier, higher tiers can go further). Or reduce the corpus
+size via `--corpus <smaller-fixture>`.
+
+**Auth failure during dispatch** — Confirm `ANTHROPIC_API_KEY` is set at the
+repo level (Settings → Secrets) and that the substrate dispatcher actually
+respects it in CI. Story 81-6 should verify this end-to-end.
+
+**Comment posting fails with 403** — Confirm the workflow has
+`permissions: pull-requests: write`. Also note that the safety boundary
+`if: github.event.pull_request.head.repo.full_name == github.repository`
+skips fork PRs intentionally — secret-scoped behavior on forks is undefined
+and a separate design discussion.
+
+## Related docs
+
+- `docs/2026-05-31-epic-81-first-calibration.md` — architectural finding +
+  Story 81-6 scope (READ THIS FIRST)
+- `_bmad-output/planning-artifacts/epic-81-pack-upgrade-ab-validation.md` —
+  full Epic 81 plan
+- `_bmad-output/implementation-artifacts/81-5-pack-upgrade-ci-integration.md` —
+  this story's full AC spec


### PR DESCRIPTION
## Summary

Ships the Story 81-5 Pack-Upgrade CI integration:
- `.github/workflows/eval-pack-upgrade.yml` — triggers on PRs touching `packs/bmad/**`; runs `scripts/eval-pack-upgrade.mjs` (base pack vs PR pack); posts the four-axis markdown report as a PR comment (update-in-place); uploads markdown+JSON as artifacts (90-day retention).
- `docs/eval-pack-upgrade-ci-setup.md` — operator setup + troubleshooting + promotion-to-gate criteria.

## ⚠️ Capability gap: Story 81-6 needed before this gate produces real signal

This PR ships the workflow infrastructure but the workflow currently posts **vacuous GREEN** on every pack-upgrade PR.

**Why**: both substrate eval harnesses (Epic 77 reconstruction AND Epic 81 pack-upgrade) ship with `deps.dispatch` STUBBED. The dev agents who built Stories 77-8 and 81-2 explicitly deferred the production dispatch wiring as out of scope. When dispatch throws, every pair returns `both-incomplete`, the grader sees zero gradable pairs, and the overall verdict defaults to GREEN by absence of regressions to detect.

**The full architectural finding + Story 81-6 scope** are in `docs/2026-05-31-epic-81-first-calibration.md` (already merged to main). Quick summary:
- Story 81-6 wires `createDispatcher` from `@substrate-ai/core` into BOTH eval harnesses' `deps.dispatch`
- Adds an additive pack-override mechanism on the dispatcher (forward-only schema-style)
- Wires API-key auth for CI dispatch
- ~300–500 LOC; unlocks BOTH Epic 77 reconstruction AND Epic 81 pack-upgrade in one ship

## 🔑 Required GitHub secret (manual operator step)

Before merging, add this secret at **Settings → Secrets and variables → Actions**:

```
ANTHROPIC_API_KEY  — substrate dispatch in CI uses API-key auth (OAuth session unavailable in GHA)
```

I cannot add repo secrets via API/CLI — this is the one human step in the goal sequence. Without this secret the workflow will fail to dispatch even after 81-6 lands.

## 4.2 (deliberate-regression) status

Not run this session. With the dispatcher stubbed, both pack-current and pack-degraded would return `dispatch_outcome: 'error'` and the test would surface the same vacuous GREEN as Phase 4.1 — not a meaningful regression-detection test. Phase 4.2 + Phase 5.3 (end-to-end PR-comment confirmation against a real diff) become runnable once Story 81-6 lands.

## Suggested merge sequence

1. **Now**: review this PR; if approving, add `ANTHROPIC_API_KEY` secret and merge. Workflow becomes live but posts vacuous GREEN until 81-6.
2. **Next**: file + dispatch Story 81-6 (production dispatcher wiring). Filed in docs/2026-05-31-epic-81-first-calibration.md with full scope. Substrate-dispatchable.
3. **After 81-6 ships**: re-run Phase 4.2 against `_bmad-output/eval-results/corpus/pack-upgrade-fixture-corpus.yaml` (4-pair fixture committed to main); confirm deliberate-regression detection; tune thresholds.
4. **After 2–3 calibration runs**: flip workflow from report-only to blocking-gate per docs/eval-pack-upgrade-ci-setup.md promotion criteria.

## Files

- `.github/workflows/eval-pack-upgrade.yml`
- `docs/eval-pack-upgrade-ci-setup.md`

## Goal context

This PR closes the Phase 5.1 step of the autonomous /goal session targeting Epic 81 end-to-end validation. Phases 1–3 (stories 81-1 through 81-4) merged earlier in the session. Phase 4 halted at the dispatcher-stub finding. This PR satisfies the goal's "81-5 PR open with secret-name surfaced" success criterion; the goal's "4.2 caught the deliberate regression" criterion is genuinely blocked on Story 81-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)